### PR TITLE
Make this bundle compatible with symfony4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 matrix:
   include:
-    - php: 7.0
-    - php: 7.1
+    - php: 7.3
+    - php: 7.4
   fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     },
     "require": {
         "php": ">=7.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
-        "symfony/event-dispatcher": "~2.8|~3.0",
-        "symfony/http-kernel": "~2.8|~3.0",
-        "symfony/stopwatch": "~2.8|~3.0",
-        "phpro/soap-client": "~0.2"
+        "symfony/dependency-injection": "~2.8|~3.0|~4.0",
+        "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+        "symfony/http-kernel": "~2.8|~3.0|~4.0",
+        "symfony/stopwatch": "~2.8|~3.0|~4.0",
+        "phpro/soap-client": "~1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.2",

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,18 @@
         }
     },
     "require": {
-        "php": ">=7.0",
-        "symfony/dependency-injection": "~2.8|~3.0|~4.0",
-        "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-        "symfony/http-kernel": "~2.8|~3.0|~4.0",
-        "symfony/stopwatch": "~2.8|~3.0|~4.0",
-        "phpro/soap-client": "~1.0"
+        "php": ">=7.1",
+        "symfony/dependency-injection": "~3.0|~4.0",
+        "symfony/event-dispatcher": "~3.0|~4.0",
+        "symfony/http-kernel": "~3.0|~4.0",
+        "symfony/stopwatch": "~3.0|~4.0",
+        "phpro/soap-client": "~1.0",
+        "ext-dom": "*"
     },
     "require-dev": {
-        "phpspec/phpspec": "~2.2",
-        "squizlabs/php_codesniffer": "~2.3",
-        "phpunit/phpunit": "4.*",
-        "phpro/grumphp": "~0.5"
+        "phpspec/phpspec": "~6",
+        "squizlabs/php_codesniffer": "~3",
+        "phpunit/phpunit": "9.*",
+        "phpro/grumphp": "~0.19"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.3",
         "symfony/dependency-injection": "~3.0|~4.0",
         "symfony/event-dispatcher": "~3.0|~4.0",
         "symfony/http-kernel": "~3.0|~4.0",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
-parameters:
-    git_dir: .
-    bin_dir: ./vendor/bin
+grumphp:
     tasks:
         phpcs:
             standard: "PSR2"

--- a/spec/Phpro/SoapClient/BridgeBundle/DataCollector/SoapCallCollectorSpec.php
+++ b/spec/Phpro/SoapClient/BridgeBundle/DataCollector/SoapCallCollectorSpec.php
@@ -8,7 +8,6 @@ use Phpro\SoapClient\Event\ResponseEvent;
 use Phpro\SoapClient\Events;
 use Phpro\SoapClient\Type\ResultInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class SoapCallCollectorSpec extends ObjectBehavior
 {
@@ -22,14 +21,20 @@ class SoapCallCollectorSpec extends ObjectBehavior
         $this->shouldImplement('Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
     }
 
-    function it_should_subscribe_to_events() {
+    function it_should_subscribe_to_events()
+    {
         $this->getSubscribedEvents()->shouldHaveKeyWithValue(Events::RESPONSE, 'onClientResponse');
         $this->getSubscribedEvents()->shouldHaveKeyWithValue(Events::REQUEST, 'onClientRequest');
     }
 
     function it_should_be_able_to_register_a_request(
         RequestEvent $requestEvent
-    ) {
+    )
+    {
+        $requestEvent->getRequest()->shouldBeCalled();
+        $requestEvent->getMethod()->shouldBeCalled();
+        $requestEvent->getClient()->shouldBeCalled();
+
         $this->onClientRequest($requestEvent);
         $this->getCalls()->shouldHaveCount(1);
     }
@@ -41,23 +46,29 @@ class SoapCallCollectorSpec extends ObjectBehavior
         ResponseEvent $responseEvent
     ) {
         $debugData = [
-            'request'  => ['headers' => 'SoapRequestHeader', 'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapRequestBody</body>'],
-            'response' => ['headers' => 'SoapResponseHeader', 'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapResponseBody</body>'],
+                'request'  => ['headers' => 'SoapRequestHeader', 'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapRequestBody</body>'],
+                'response' => ['headers' => 'SoapResponseHeader', 'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapResponseBody</body>'],
         ];
         $client->debugLastSoapRequest()->willReturn($debugData);
         $responseEvent->getResponse()->willReturn($result);
         $responseEvent->getClient()->willReturn($client);
+
+        $requestEvent->getRequest()->shouldBeCalled();
+        $requestEvent->getMethod()->shouldBeCalled();
+        $requestEvent->getClient()->shouldBeCalled();
 
         $this->onClientRequest($requestEvent);
         $this->onClientResponse($responseEvent);
         $this->getCalls()->shouldHaveCount(1);
     }
 
-    function it_should_register_the_correct_name() {
+    function it_should_register_the_correct_name()
+    {
         $this->getName()->shouldBe('phpro.soap_client');
     }
 
-    function it_should_return_a_total_timing() {
+    function it_should_return_a_total_timing()
+    {
         $this->getTotalTiming()->shouldBe(0);
     }
 }

--- a/spec/Phpro/SoapClient/BridgeBundle/Type/SoapCallSpec.php
+++ b/spec/Phpro/SoapClient/BridgeBundle/Type/SoapCallSpec.php
@@ -29,16 +29,17 @@ class SoapCallSpec extends ObjectBehavior
         RequestEvent $event,
         RequestInterface $request,
         ClientInterface $client
-    ) {
+    )
+    {
         $event->getRequest()->willReturn($request);
         $event->getMethod()->willReturn('soapMethod');
-        $event->getClient()->willReturn($client);
+        $event->getClient()->shouldBeCalled();
         $stopwatch->start(Argument::type('string'))->shouldBeCalled();
 
         $this->setRequest($event);
         $this->getMethod()->shouldBe('soapMethod');
         $this->getRequest()->shouldBe($request);
-        $this->getHash()->shouldStartWith('Double\ClientInterface');
+        $this->getHash()->shouldStartWith('Double\Phpro\SoapClient\Client');
     }
 
     function it_should_stop_request(
@@ -47,7 +48,26 @@ class SoapCallSpec extends ObjectBehavior
         RequestEvent $requestEvent,
         ResultInterface $result,
         Client $client
-    ) {
+    )
+    {
+
+        $debugData = [
+            'request' => [
+                'headers' => 'SoapRequestHeader',
+                'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapRequestBody</body>'
+            ],
+            'response' => [
+                'headers' => 'SoapResponseHeader',
+                'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapResponseBody</body>'
+            ],
+        ];
+
+        $client->debugLastSoapRequest()->willReturn($debugData);
+
+        $requestEvent->getRequest()->shouldBeCalled();
+        $requestEvent->getMethod()->shouldBeCalled();
+        $requestEvent->getClient()->willReturn($client);
+
         $responseEvent->getResponse()->willReturn($result);
         $responseEvent->getClient()->willReturn($client);
         $stopwatch->start(Argument::type('string'))->shouldBeCalled();
@@ -62,9 +82,10 @@ class SoapCallSpec extends ObjectBehavior
         RequestEvent $requestEvent,
         ResultInterface $result,
         Client $client
-    ) {
+    )
+    {
         $debugData = [
-            'request'  => [
+            'request' => [
                 'headers' => 'SoapRequestHeader',
                 'body' => '<?xml version="1.0" encoding="UTF-8"?><body>SoapRequestBody</body>'
             ],
@@ -74,6 +95,11 @@ class SoapCallSpec extends ObjectBehavior
             ],
         ];
         $client->debugLastSoapRequest()->willReturn($debugData);
+
+        $requestEvent->getRequest()->shouldBeCalled();
+        $requestEvent->getMethod()->shouldBeCalled();
+        $requestEvent->getClient()->willReturn($client);
+
         $responseEvent->getResponse()->willReturn($result);
         $responseEvent->getClient()->willReturn($client);
 

--- a/src/Phpro/SoapClient/BridgeBundle/DataCollector/SoapCallCollector.php
+++ b/src/Phpro/SoapClient/BridgeBundle/DataCollector/SoapCallCollector.php
@@ -124,4 +124,9 @@ class SoapCallCollector implements EventSubscriberInterface, DataCollectorInterf
         }
         return $timing;
     }
+
+    public function reset()
+    {
+        $this->data = [];
+    }
 }


### PR DESCRIPTION
Fixes #9 and allows using this bundle in Symfony4 repos.

Personally, I have tried this together with [Monofony](https://github.com/Monofony/Monofony) which relies on Symfony 4.4.8 in my repo.

I kinda did monkey patching regarding tests, trying to make them work. don't know for sure if what I added in there actually helps or just makes the build pass. 

for me, it would be enough to just use my fork my project, but I hope that this PR will get merged and a new tag will be released, making this bundle useful for others as well.